### PR TITLE
ci: add "All checks passed" aggregate gate

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -315,3 +315,23 @@ jobs:
       - name: e2e tests
         run: |
           tox -e py${{ matrix.python-version }}-linux -- -m 'e2e'
+
+  all-checks-passed:
+    name: All checks passed
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_dependencies_check
+      - linter_checks
+      - scan
+      - test
+      - e2e-tests
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One or more required jobs failed or were cancelled."
+          exit 1
+      - name: All required jobs passed
+        run: echo "OK"


### PR DESCRIPTION
## Summary

Adds a single aggregate "All checks passed" job that depends on every mandatory CI job. Used as the sole required status check for the `main`-branch protection rule, so branch protection doesn't need editing when jobs are added/removed — just update this job's `needs` list.

- Depends on: `lock_check`, `copyright_and_dependencies_check`, `linter_checks`, `scan`, `test`, `e2e-tests`
- `if: always()` → runs even when a dependency failed
- Fails if any dependency's `result` is `failure` or `cancelled`

Note: `test` and `e2e-tests` carry `continue-on-error: True`, but the meta job inspects `needs.*.result` directly — so failures still block merge via this gate.

## Test plan

- [x] Syntactically valid YAML (edited in-place, lints clean)
- [ ] Once merged, confirm "All checks passed" appears as a status check on the next PR and passes when all dependencies pass
- [ ] Apply branch protection with `required_status_checks.contexts = ["All checks passed"]` after the first run on `main`
